### PR TITLE
# Major PR 9-15-21 - Hero-Lading Page Overhaul

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -68,7 +68,7 @@ module.exports = {
         background_color: `#81e6d9`,
         theme_color: `#81e6d9`,
         display: `minimal-ui`,
-        icon: `src/assets/images/icon.png`
+        icon: `src/assets/images/atl_heli_logo_1.png`
       }
     },
     `gatsby-plugin-offline`,

--- a/src/components/HeroBanner/index.tsx
+++ b/src/components/HeroBanner/index.tsx
@@ -2,14 +2,13 @@ import React from 'react';
 import { useStaticQuery, graphql } from 'gatsby';
 
 import Banner from 'components/ui/Banner';
-
 import { SectionTitle } from 'helpers/definitions';
 import { GatsbyImage, StaticImage } from 'gatsby-plugin-image';
 import { convertToBgImage } from 'gbimage-bridge';
 import BackgroundImage from 'gatsby-background-image';
-
 import styled from 'styled-components';
 import tw from 'tailwind.macro';
+import Carousel from 'components/ui/Carousel';
 
 interface SectionHeroBanner extends SectionTitle {
   content: string;
@@ -20,7 +19,7 @@ interface SectionHeroBanner extends SectionTitle {
 
 
 const HeroBanner: React.FC = () => {
-  const { markdownRemark, bgImage, sanityBG, sanityBnr } = useStaticQuery(graphql`
+  const { markdownRemark, banner1, banner2, banner3, bgImage1, bgImage2, bgImage3 } = useStaticQuery(graphql`
     query {
       markdownRemark(frontmatter: { category: { eq: "hero section" } }) {
         frontmatter {
@@ -36,16 +35,48 @@ const HeroBanner: React.FC = () => {
           gatsbyImageData(layout: FULL_WIDTH)
         }
       }
-      sanityBnr: sanityBanner {
+      # sanityBnr: sanityBanner {
+      #   big_text
+      #   small_text
+      #   button_link
+      #   button_text
+      # }
+      banner1: sanityBanner(banner_number: {eq: "banner_1"} ) {
         big_text
         small_text
         button_link
         button_text
       }
-      sanityBG: sanityImages {
+      banner2: sanityBanner(banner_number: {eq: "banner_2"} ) {
+        big_text
+        small_text
+        button_link
+        button_text
+      }
+      banner3: sanityBanner(banner_number: {eq: "banner_3"} ) {
+        big_text
+        small_text
+        button_link
+        button_text
+      }
+      bgImage1: sanityImages(bgImage_title: {eq: "bgImage_1"}) {
         bgImage {
           asset {
-            gatsbyImageData(layout: CONSTRAINED)
+            gatsbyImageData
+          }
+        }
+      }
+      bgImage2: sanityImages(bgImage_title: {eq: "bgImage_2"}) {
+        bgImage {
+          asset {
+            gatsbyImageData
+          }
+        }
+      }
+      bgImage3: sanityImages(bgImage_title: {eq: "bgImage_3"}) {
+        bgImage {
+          asset {
+            gatsbyImageData
           }
         }
       }
@@ -53,26 +84,63 @@ const HeroBanner: React.FC = () => {
   `);
 
   const heroBanner: SectionHeroBanner = markdownRemark.frontmatter;
-  const backgroundImage = bgImage.childImageSharp.gatsbyImageData;
-  const sanityBackground = convertToBgImage(sanityBG.bgImage.asset.gatsbyImageData);
-  const sanityBanner = sanityBnr;
+  const sanityBackground_1 = convertToBgImage(bgImage1.bgImage.asset.gatsbyImageData);
+  const sanityBackground_2 = convertToBgImage(bgImage2.bgImage.asset.gatsbyImageData);
+  const sanityBackground_3 = convertToBgImage(bgImage3.bgImage.asset.gatsbyImageData);
+  const sanityBanner_1 = banner1;
+  const sanityBanner_2 = banner2;
+  const sanityBanner_3 = banner3;
   return (
 
-    <BackgroundImage
-      Tag='section'
-      {...sanityBackground}
-      preserveStackingContext
-      className="heroBanner"
-    >
-      <Banner
-        title={sanityBanner.big_text}
-        // subtitle={heroBanner.subtitle}
-        content={sanityBanner.small_text}
-        linkTo={sanityBanner.button_link}
-        linkText={sanityBanner.button_text}
-      // bgImg={backgroundImage}
-      />
-    </BackgroundImage>
+
+    <Carousel>
+      <>
+        <BackgroundImage
+          Tag='section'
+          {...sanityBackground_1}
+          preserveStackingContext
+          className="heroBanner"
+        >
+          <Banner
+            title={sanityBanner_1.big_text}
+            content={sanityBanner_1.small_text}
+            linkTo={sanityBanner_1.button_link}
+            linkText={sanityBanner_1.button_text}
+          />
+        </BackgroundImage>
+      </>
+      <>
+        <BackgroundImage
+          Tag='section'
+          {...sanityBackground_2}
+          preserveStackingContext
+          className="heroBanner"
+        >
+          <Banner
+            title={sanityBanner_2.big_text}
+            content={sanityBanner_2.small_text}
+            linkTo={sanityBanner_2.button_link}
+            linkText={sanityBanner_2.button_text}
+          />
+        </BackgroundImage>
+      </>
+      <>
+        <BackgroundImage
+          Tag='section'
+          {...sanityBackground_3}
+          preserveStackingContext
+          className="heroBanner"
+        >
+          <Banner
+            title={sanityBanner_3.big_text}
+            content={sanityBanner_3.small_text}
+            linkTo={sanityBanner_3.button_link}
+            linkText={sanityBanner_3.button_text}
+          />
+        </BackgroundImage>
+      </>
+    </Carousel>
+
 
   );
 };

--- a/src/components/ui/Banner/styles.ts
+++ b/src/components/ui/Banner/styles.ts
@@ -11,5 +11,5 @@ export const Content = styled.p`
 `;
 
 export const Title = styled.h1`
-  ${tw`uppercase mb-1 sm:mb-5 text-lg sm:text-3xl text-black w-full text-center`};
+  ${tw`uppercase mb-1 sm:mb-5 text-lg sm:text-3xl text-lightRed w-full text-center`};
 `;


### PR DESCRIPTION
## Additions: 
- Complete overhaul of hero-landing page now with a carousel of scrolling 'bg' images. reworked static queries accordingly
- Restructuring of Sanity backend also occurred

## Notes:
- Currently the static queries for the banner text and photos isn't very dynamic and limits to 3 photos and rigid structure of naming on backend, consider re-working later