### PR TITLE
Major PR 12-12-21 Container and Header Alteration and Grid-Layout Tours Page

### DIFF
--- a/frontend/src/assets/styles/global.css
+++ b/frontend/src/assets/styles/global.css
@@ -85,12 +85,6 @@
   display: none;
 }
 
-.testGif {
-  background-image: url('../images/helo-ex-3.gif');
-  background-position: center;
-  background-size: cover;
-}
-
 .heroBanner {
   height: 100vh;
 }
@@ -112,7 +106,7 @@
 }
 
 .scrolledHeadWrapper {
-  margin-left: 20rem;
+  margin-left: 0rem;
 }
 
 .transparent {

--- a/frontend/src/components/Header/Logo/styles.ts
+++ b/frontend/src/components/Header/Logo/styles.ts
@@ -3,7 +3,7 @@ import tw from 'tailwind.macro';
 import { Link } from 'gatsby';
 
 export const Logo = styled(Link)`
-  ${tw`flex items-center lg:w-auto lg:mr-auto text-black hover:text-indigo-900`};
+  ${tw`flex items-center lg:w-auto text-black hover:text-indigo-900`};
 `;
 
 export const Text = styled.h1`
@@ -12,8 +12,8 @@ export const Text = styled.h1`
 `;
 
 export const Image = styled.figure`
-  ${tw`-ml-8 mr-2 py-1 sm:-ml-6 sm:py-0 `};
-
+  /* ${tw`-ml-8 mr-2 py-1 sm:-ml-6 sm:py-0 `}; */
+  ${tw`m-1 p-1`}
   /* img {
     ${tw`h-full w-full rounded-full border border-red`};
   } */

--- a/frontend/src/components/Header/MainNav/styles.ts
+++ b/frontend/src/components/Header/MainNav/styles.ts
@@ -13,7 +13,7 @@ export const MainNav = styled.nav<StyledProps>`
 `;
 
 export const MainNavItem = motion.custom(styled(Link)`
-  ${tw`relative text-black sm:text-lg border-b border-transparent hover:text-indigo-900 ml-0 sm:ml-8 mt-3 sm:mt-0`};
+  ${tw`relative text-black sm:text-lg border-b border-transparent hover:text-white ml-0 sm:ml-8 mt-3 sm:mt-0`};
   font-family: "GoodTimes", monospace;
   width: max-content;
 

--- a/frontend/src/components/Header/styles.ts
+++ b/frontend/src/components/Header/styles.ts
@@ -15,7 +15,7 @@ export const Header = styled.header`
 
 export const Wrapper = styled(Container)<ScrollStyles>`
   ${tw`min-h-full items-center justify-around`};
-  ${ ({scrolled}) => scrolled && `margin-left: 14rem;`}
+  ${ ({scrolled}) => scrolled && `margin-left: 0rem;`}
   
 `;
 

--- a/frontend/src/components/HeroBanner/index.tsx
+++ b/frontend/src/components/HeroBanner/index.tsx
@@ -13,8 +13,6 @@ import Button from 'components/ui/Button';
 
 import TourModal from '../ui/TourModal';
 
-import Helo3Gif from "../../assets/images/helo-ex-3.gif";
-
 // interface SectionHeroBanner extends SectionTitle {
 //   content: string;
 //   linkTo: string;
@@ -161,14 +159,6 @@ const HeroBanner: React.FC = () => {
 
 
     <>
-      {/* <div className='testGif'>
-        <Banner
-          title={sanityBanner_1.big_text}
-          content={sanityBanner_1.small_text}
-          linkTo={sanityBanner_1.button_link}
-          linkText={sanityBanner_1.button_text}
-        />
-      </div> */}
 
       <BackgroundImage
         Tag='section'

--- a/frontend/src/components/TourInfo/index.tsx
+++ b/frontend/src/components/TourInfo/index.tsx
@@ -63,23 +63,24 @@ const TourInfo: React.FC<XolaExperienceArray> = ({ toursArray }) => {
           All winery/chophouse excursions are total price <strong>up to 3 people</strong><br />
           Find the perfect fit of time and destinations for you below!
         </Styled.h3>
-
-        {
-          buildTours.map((tour: any) => {
-            const {
-              id,
-              name,
-              description,
-              price,
-              photoLink
-            } = tour.node;
-            return (
-              <Styled.TourInfoItem key={id}  >
-                <TourCard id={id} name={name} description={description} price={price} photoLink={photoLink} />
-              </Styled.TourInfoItem>
-            );
-          })
-        }
+        <Styled.TourGrid>
+          {
+            buildTours.map((tour: any) => {
+              const {
+                id,
+                name,
+                description,
+                price,
+                photoLink
+              } = tour.node;
+              return (
+                <Styled.TourInfoItem key={id}  >
+                  <TourCard id={id} name={name} description={description} price={price} photoLink={photoLink} />
+                </Styled.TourInfoItem>
+              );
+            })
+          }
+        </Styled.TourGrid>
 
         {/* {
           toursArray.map((tour) => {

--- a/frontend/src/components/TourInfo/styles.ts
+++ b/frontend/src/components/TourInfo/styles.ts
@@ -1,8 +1,14 @@
 import styled from 'styled-components';
 import tw from 'tailwind.macro';
 
+export const TourGrid = styled.section`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+`;
+
 export const TourInfoItem = styled.div`
-  ${tw`w-full sm:w-5/6`};
+  justify-self: center;
+  ${tw`w-full sm:w-11/12 sm:h-3/6`};
 `;
 
 export const h3 = styled.h3`
@@ -12,3 +18,4 @@ export const h3 = styled.h3`
 export const Icon = styled.span`
   ${tw`flex items-center justify-center w-12 h-12 text-black border border-lightRed rounded-full`};
 `;
+

--- a/frontend/src/components/ui/Container/styles.ts
+++ b/frontend/src/components/ui/Container/styles.ts
@@ -6,6 +6,6 @@ export interface StyledProps {
 }
 
 export const Container = styled.div<StyledProps>`
-  ${tw`flex flex-wrap justify-center max-w-screen-xl w-full mx-auto p-2`};
+  ${tw`flex flex-wrap justify-center max-w-screen-2xl w-full mx-auto p-2`};
   ${({ section }) => section && tw`flex-col items-center mx-auto sm:mt-24 py-8 sm:py-12`};
 `;

--- a/frontend/src/components/ui/TourCard/index.tsx
+++ b/frontend/src/components/ui/TourCard/index.tsx
@@ -36,9 +36,9 @@ interface TourCardXola extends Styled.StyledProps {
 const TourCard: React.FC<TourCardXola> = ({ id, center, name, description, price, priceType, photoLink, cancellationPolicy }) => (
 
   <Styled.TourCard center={center} id={id}>
-    <img src={`${process.env.GATSBY_IMG_TEST}${photoLink}_723x542.jpg`} />
+    {/* <img src={`${process.env.GATSBY_IMG_TEST}${photoLink}_723x542.jpg`} /> */}
     <Styled.Wrapper center={center}>
-      <Styled.Link center target="_blank" href={`https://checkout.xola.com/index.html#seller/${process.env.GATSBY_XOLA_SELLER_ID}/experiences/${id}?openExternal=true`}>
+      <div style={{ backgroundImage: `url(${process.env.GATSBY_IMG_TEST}${photoLink}_723x542.jpg)`, backgroundPosition: 'center', backgroundSize: 'cover', height: '400px' }}>
         <Styled.Title>{name}</Styled.Title>
         <Styled.Content>{description}</Styled.Content>
         <Styled.Wrapper topPad>
@@ -47,9 +47,11 @@ const TourCard: React.FC<TourCardXola> = ({ id, center, name, description, price
               <Styled.h3>${price}</Styled.h3>
             </Styled.priceDiv>
           </motion.div>
-          <Button>Click to book!</Button>
+          <Styled.Link center target="_blank" href={`https://checkout.xola.com/index.html#seller/${process.env.GATSBY_XOLA_SELLER_ID}/experiences/${id}?openExternal=true`}>
+            <Button>Click to book!</Button>
+          </Styled.Link>
         </Styled.Wrapper>
-      </Styled.Link>
+      </div>
     </Styled.Wrapper>
   </Styled.TourCard>
 

--- a/frontend/src/components/ui/TourCard/styles.ts
+++ b/frontend/src/components/ui/TourCard/styles.ts
@@ -7,7 +7,7 @@ export interface StyledProps {
 }
 
 export const TourCard = styled.div<StyledProps>`
-  ${tw`flex flex-col my-4 mx-3 p-2 bg-white rounded-lg border border-gray-300 hover:border- hover:bg-offWhite`};
+  ${tw`flex flex-col sm:h-full my-2 mx-2 p-2 rounded-lg border border-gray-300 hover:border- hover:bg-offWhite`};
   ${({ center }) => center && tw`items-center items-center`};
 `;
 
@@ -30,7 +30,7 @@ export const Content = styled.p`
 `;
 
 export const Link = styled.a<StyledProps>`
-  ${tw`flex flex-col my-4 mx-3 p-4 bg-white rounded-lg border border-gray-300`};
+  ${tw`flex flex-col my-1 mx-1 p-2 rounded-lg`};
   ${({ center }) => center && tw`items-center items-center`};
   Button {
     ${tw`hover:bg-lightRed`}


### PR DESCRIPTION
# Additions-Modifications
- See commit comment history for full info, but this PR includes major changes to the Container component (widening it to 1600px max-width), the Header Component's logo figure element had it's styled components drastically reduced in complexity, removing negative margins, etc that were previously being used to fight the Container's auto-margins. 
- The Tours and Charters page is redone with a Grid layout instead of flex with currently just 2 cards per row. 
- Tour Cards themselves were redone to now have a simple div with the background-covered image being the tour's associated xola photo-image. This needs to be revisited and moved to a styled-component instead of a 'floating' div.
- Margins, padding, etc changed on Tour Cards
- The link element now only wraps the button itself instead of the entire TourCard. 
- Will need to revisit  coloring of text and how much text we want on each Tour Card.
