### PR TITLE
PR 12-16-21 - Service-Card-Remake

### DIFF
--- a/backend/schemas/documents/services.js
+++ b/backend/schemas/documents/services.js
@@ -23,5 +23,10 @@ export default {
       name: "service_link",
       type: "string",
     },
+    {
+      title: "Service Background Image",
+      name: "service_bg_image",
+      type: "image",
+    },
   ],
 };

--- a/frontend/src/components/Services/index.tsx
+++ b/frontend/src/components/Services/index.tsx
@@ -9,6 +9,7 @@ import { motion } from 'framer-motion';
 import { SectionTitle } from 'helpers/definitions';
 
 import * as Styled from './styles';
+import { IGatsbyImageData } from 'gatsby-plugin-image';
 
 interface Service {
   node: {
@@ -28,6 +29,12 @@ interface SanityService {
     service_name: string;
     service_icon: IconProps;
     service_link: string;
+    service_bg_image: {
+      asset: {
+        url: string;
+        gatsbyImageData: IGatsbyImageData;
+      }
+    }
   }
 }
 
@@ -61,6 +68,12 @@ const Services: React.FC = () => {
             service_icon
             service_name
             service_link
+            service_bg_image {
+              asset {
+                url
+                gatsbyImageData
+              }
+            }
           }
         }
       }
@@ -82,13 +95,14 @@ const Services: React.FC = () => {
             service_description,
             service_icon,
             service_link,
-            service_name
+            service_name,
+            service_bg_image
           } = item.node;
 
           return (
             <Styled.ServiceItem key={id}>
               <motion.div whileHover={{ scale: 1.10 }} whileTap={{ scale: 1.05 }} style={{ height: '100%', width: '100%' }} >
-                <InfoBlock linkTo={service_link} icon={service_icon} title={service_name} content={service_description} />
+                <InfoBlock linkTo={service_link} icon={service_icon} title={service_name} content={service_description} bgImage={service_bg_image.asset.url} />
               </motion.div>
             </Styled.ServiceItem>
           );

--- a/frontend/src/components/ui/InfoBlock/index.tsx
+++ b/frontend/src/components/ui/InfoBlock/index.tsx
@@ -2,16 +2,18 @@ import React from 'react';
 import { Link } from 'gatsby';
 import Icon, { IconProps } from 'components/ui/Icon';
 import * as Styled from './styles';
+import { IGatsbyImageData } from 'gatsby-plugin-image';
 
 interface Props extends Styled.StyledProps {
   title: string;
   content: React.ReactNode;
   icon: IconProps;
   linkTo: string;
+  bgImage: IGatsbyImageData | string;
 }
 
-const InfoBlock: React.FC<Props> = ({ icon, title, content, linkTo, center }) => (
-  <Styled.InfoBlock center={center} >
+const InfoBlock: React.FC<Props> = ({ icon, title, content, linkTo, center, bgImage }) => (
+  <Styled.InfoBlock center={center} bgImage={bgImage} >
     <Styled.Icon>
       <Icon icon={icon} />
     </Styled.Icon>

--- a/frontend/src/components/ui/InfoBlock/styles.ts
+++ b/frontend/src/components/ui/InfoBlock/styles.ts
@@ -1,12 +1,15 @@
+import { IGatsbyImageData } from 'gatsby-plugin-image';
 import styled from 'styled-components';
 import tw from 'tailwind.macro';
 
 export interface StyledProps {
   center?: boolean;
+  bgImage?: IGatsbyImageData | string;
 }
 
 export const InfoBlock = styled.div<StyledProps>`
-  ${tw`flex flex-col sm:min-h-full my-4 mx-3 p-4 bg-white rounded-lg border border-gray-300`};
+  ${({ bgImage }) => bgImage && `background-image: url(${bgImage}); background-position: center; background-size: cover; background-repeat: no-repeat; `}
+  ${tw`flex flex-col sm:min-h-full my-4 mx-3 p-4 rounded-lg border border-gray-300`};
   ${({ center }) => center && tw`items-center items-center`};
 `;
 
@@ -15,7 +18,14 @@ export const Icon = styled.span`
 `;
 
 export const Wrapper = styled.div<StyledProps>`
+  ${tw`p-2 m-2`}
+  background-color: transparent;
+  opacity: 0.7;
   ${({ center }) => center && tw`text-center`};
+  &:hover {
+    background-color: white;
+    opacity: 0.6;
+  }
 `;
 
 export const Title = styled.h3`

--- a/frontend/src/components/ui/TourCard/index.tsx
+++ b/frontend/src/components/ui/TourCard/index.tsx
@@ -24,23 +24,25 @@ const hoverHandler = (event: any) => {
 const TourCard: React.FC<TourCardXolaProps> = ({ id, center, name, description, price, priceType, photoLink, cancellationPolicy }) => (
 
   <Styled.TourCard center={center} id={id}>
-    {/* <img src={`${process.env.GATSBY_IMG_TEST}${photoLink}_723x542.jpg`} /> */}
-    <Styled.Wrapper photoLink={photoLink} onFocus={e => hoverHandler(e)} hovering >
-      {/* <div style={{ backgroundImage: `url(${process.env.GATSBY_IMG_TEST}${photoLink}_723x542.jpg)`, backgroundPosition: 'center', backgroundSize: 'cover', height: '400px' }}> */}
-      <Styled.Title>{name}</Styled.Title>
-      <Styled.Content>{description}</Styled.Content>
-      <Styled.PriceLink topPad>
-        <motion.div whileHover={{ scale: 1.20 }} whileTap={{ scale: 1.15 }} >
-          <Styled.priceDiv>
-            <Styled.h3>${price}</Styled.h3>
-          </Styled.priceDiv>
-        </motion.div>
-        <Styled.Link center target="_blank" href={`https://checkout.xola.com/index.html#seller/${process.env.GATSBY_XOLA_SELLER_ID}/experiences/${id}?openExternal=true`}>
-          <Button>Click to book!</Button>
-        </Styled.Link>
-      </Styled.PriceLink>
-      {/* </div> */}
-    </Styled.Wrapper>
+    <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 1.08 }} >
+      {/* <img src={`${process.env.GATSBY_IMG_TEST}${photoLink}_723x542.jpg`} /> */}
+      <Styled.Wrapper photoLink={photoLink} onFocus={e => hoverHandler(e)} hovering >
+        {/* <div style={{ backgroundImage: `url(${process.env.GATSBY_IMG_TEST}${photoLink}_723x542.jpg)`, backgroundPosition: 'center', backgroundSize: 'cover', height: '400px' }}> */}
+        <Styled.Title>{name}</Styled.Title>
+        <Styled.Content>{description}</Styled.Content>
+        <Styled.PriceLink topPad>
+          <motion.div whileHover={{ scale: 1.20 }} whileTap={{ scale: 1.15 }} >
+            <Styled.priceDiv>
+              <Styled.h3>${price}</Styled.h3>
+            </Styled.priceDiv>
+          </motion.div>
+          <Styled.Link center target="_blank" href={`https://checkout.xola.com/index.html#seller/${process.env.GATSBY_XOLA_SELLER_ID}/experiences/${id}?openExternal=true`}>
+            <Button>Click to book!</Button>
+          </Styled.Link>
+        </Styled.PriceLink>
+        {/* </div> */}
+      </Styled.Wrapper>
+    </motion.div>
   </Styled.TourCard>
 
 )


### PR DESCRIPTION
# Additions:
- This merge commit carries over a few remaining changes made to the TourCard (TourInfo) components, please see commit messages and diffs for details.
- Otherwise this PR addresses adding what the client feels is a more 'modern' look to the site, mainly by adding images to everything .. In this case we're adding stock (mock) images to the service cards found on the landing page. 
- We updated our Sanity backend schema to accept an image in the Services section (for each service card).
- Ran the graphql static query for the base url (not the gatsbyImageData prop) for the images, passing it down to the underlying InfoBlock component.
- In InfoBlock we very quickly styled to have an on-hover effect with transparency, opacity, and bg-coloring