### PR TITLE
PR #22 12-18-21 - Tours-Charters-Grid-Reformat-Mobile

### DIFF
--- a/frontend/src/components/TourInfo/index.tsx
+++ b/frontend/src/components/TourInfo/index.tsx
@@ -5,7 +5,7 @@ import { useStaticQuery, graphql } from 'gatsby';
 import Container from 'components/ui/Container';
 import TitleSection from 'components/ui/TitleSection';
 import TourCard from 'components/ui/TourCard';
-
+import { motion } from 'framer-motion';
 
 
 import * as Styled from './styles';
@@ -75,7 +75,9 @@ const TourInfo: React.FC<XolaExperienceArray> = ({ toursArray }) => {
               } = tour.node;
               return (
                 <Styled.TourInfoItem key={id}  >
-                  <TourCard id={id} name={name} description={description} price={price} photoLink={photoLink} />
+                  <motion.div whileHover={{ scale: 1.03 }} whileTap={{ scale: 1.03 }} style={{ height: '100%', width: '100%' }} >
+                    <TourCard id={id} name={name} description={description} price={price} photoLink={photoLink} />
+                  </motion.div>
                 </Styled.TourInfoItem>
               );
             })

--- a/frontend/src/components/TourInfo/styles.ts
+++ b/frontend/src/components/TourInfo/styles.ts
@@ -3,12 +3,20 @@ import tw from 'tailwind.macro';
 
 export const TourGrid = styled.section`
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-rows: 1fr 1fr 1fr;
+  grid-gap: 1rem;
+
+  @media screen and (max-width: 425px) {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
 `;
 
 export const TourInfoItem = styled.div`
   justify-self: center;
-  ${tw`w-full sm:w-11/12 sm:h-3/6`};
+  ${tw`w-full p-1 m-1`};
 `;
 
 export const h3 = styled.h3`

--- a/frontend/src/components/ui/InfoBlock/styles.ts
+++ b/frontend/src/components/ui/InfoBlock/styles.ts
@@ -24,17 +24,8 @@ export const Icon = styled.span`
 `;
 
 export const Wrapper = styled.div<StyledProps>`
-  height: 100%;
-  ${tw`p-2 m-2`}
-  background-color: transparent;
-  opacity: 0.75;
-  ${({ center }) => center && tw`text-center`};
-  &:hover { 
-    background-color: white;
-    opacity: 0.80;
-    border: 1px solid black;
-    border-radius: 10px;
-  }
+  ${tw`p-2 m-2 h-full bg-transparent opacity-75`}
+  ${tw`hover:bg-white hover:opacity-80 hover:border hover:border-red hover:rounded-lg`}
 `;
 
 export const Title = styled.h3`

--- a/frontend/src/components/ui/TourCard/index.tsx
+++ b/frontend/src/components/ui/TourCard/index.tsx
@@ -14,35 +14,30 @@ interface TourCardXolaProps extends Styled.StyledProps {
   cancellationPolicy?: string;
   price: number;
   priceType?: string;
-  hovering?: boolean;
-}
-
-const hoverHandler = (event: any) => {
-  return event ? true : false;
 }
 
 const TourCard: React.FC<TourCardXolaProps> = ({ id, center, name, description, price, priceType, photoLink, cancellationPolicy }) => (
 
-  <Styled.TourCard center={center} id={id}>
-    <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 1.08 }} >
-      {/* <img src={`${process.env.GATSBY_IMG_TEST}${photoLink}_723x542.jpg`} /> */}
-      <Styled.Wrapper photoLink={photoLink} onFocus={e => hoverHandler(e)} hovering >
-        {/* <div style={{ backgroundImage: `url(${process.env.GATSBY_IMG_TEST}${photoLink}_723x542.jpg)`, backgroundPosition: 'center', backgroundSize: 'cover', height: '400px' }}> */}
-        <Styled.Title>{name}</Styled.Title>
-        <Styled.Content>{description}</Styled.Content>
-        <Styled.PriceLink topPad>
-          <motion.div whileHover={{ scale: 1.20 }} whileTap={{ scale: 1.15 }} >
-            <Styled.priceDiv>
-              <Styled.h3>${price}</Styled.h3>
-            </Styled.priceDiv>
-          </motion.div>
-          <Styled.Link center target="_blank" href={`https://checkout.xola.com/index.html#seller/${process.env.GATSBY_XOLA_SELLER_ID}/experiences/${id}?openExternal=true`}>
-            <Button>Click to book!</Button>
-          </Styled.Link>
-        </Styled.PriceLink>
-        {/* </div> */}
-      </Styled.Wrapper>
-    </motion.div>
+  <Styled.TourCard photoLink={photoLink} center={center} id={id}>
+    {/* <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 1.08 }} > */}
+    {/* <img src={`${process.env.GATSBY_IMG_TEST}${photoLink}_723x542.jpg`} /> */}
+    <Styled.Wrapper >
+      {/* <div style={{ backgroundImage: `url(${process.env.GATSBY_IMG_TEST}${photoLink}_723x542.jpg)`, backgroundPosition: 'center', backgroundSize: 'cover', height: '400px' }}> */}
+      <Styled.Title>{name}</Styled.Title>
+      <Styled.Content>{description}</Styled.Content>
+      <Styled.PriceLink topPad>
+        <motion.div whileHover={{ scale: 1.20 }} whileTap={{ scale: 1.15 }} >
+          <Styled.priceDiv>
+            <Styled.h3>${price}</Styled.h3>
+          </Styled.priceDiv>
+        </motion.div>
+        <Styled.Link center target="_blank" href={`https://checkout.xola.com/index.html#seller/${process.env.GATSBY_XOLA_SELLER_ID}/experiences/${id}?openExternal=true`}>
+          <Button>Click to book!</Button>
+        </Styled.Link>
+      </Styled.PriceLink>
+      {/* </div> */}
+    </Styled.Wrapper>
+    {/* </motion.div> */}
   </Styled.TourCard>
 
 )

--- a/frontend/src/components/ui/TourCard/styles.ts
+++ b/frontend/src/components/ui/TourCard/styles.ts
@@ -5,12 +5,16 @@ export interface StyledProps {
   center?: boolean;
   topPad?: boolean;
   photoLink?: string;
-  hovering?: boolean;
 }
 
 export const TourCard = styled.div<StyledProps>`
-  ${tw`flex flex-col sm:h-card justify-center items-center my-2 mx-2 p-2 rounded-lg border border-gray-300 hover:border- hover:bg-offWhite`};
-  ${({ center }) => center && tw`items-center`};
+  ${({ photoLink }) => photoLink && `height: 400px; background-image: url(${process.env.GATSBY_IMG_TEST}${photoLink}_723x542.jpg); background-position: center; background-size: cover; filter: brightness(.72)`};
+  ${tw`flex flex-col shadow-xl justify-center p-4 rounded-lg border border-gray-300`};
+  &:hover {
+    filter: none;
+  }
+  transition: filter 280ms ease-out;
+ 
 `;
 
 export const Icon = styled.span`
@@ -18,18 +22,12 @@ export const Icon = styled.span`
 `;
 
 export const Wrapper = styled.div<StyledProps>`
-  ${tw`flex flex-col justify-around m-1 items-center text-center`};
-  ${({ photoLink }) => photoLink && `height: 400px; background-image: url(${process.env.GATSBY_IMG_TEST}${photoLink}_723x542.jpg); background-position: center; background-size: cover; filter: brightness(.7)`};
-  &:hover {
-    filter: none;
-  }
-  transition: filter 280ms ease-out;
+  ${tw`p-2 m-2 h-full bg-transparent opacity-75`}
+  ${tw`hover:bg-white hover:opacity-80 hover:border hover:border-red hover:rounded-lg`}
 `;
 
 export const PriceLink = styled.div<StyledProps>`
-  ${tw`flex flex-col justify-center m-1 items-center`};
-  ${({ center }) => center && tw`text-center`};
-  ${({ topPad }) => topPad && tw`pt-4`}
+  ${tw`flex flex-col justify-center m-1 mt-2 items-center`};
 `;
 
 export const Title = styled.h3`
@@ -39,18 +37,18 @@ export const Title = styled.h3`
 `;
 
 export const Content = styled.p`
-  ${tw`mt-1 text-white text-center`};
+  ${tw`mt-1 text-black text-center`};
 `;
 
 export const Link = styled.a<StyledProps>`
   ${tw`flex flex-col my-1 mx-1 p-2 rounded-lg`};
   ${({ center }) => center && tw`items-center items-center`};
   Button {
-    ${tw`hover:bg-lightRed`}
+    ${tw`text-red hover:text-black hover:bg-lightRed`}
   }
 `
 export const priceDiv = styled.div`
-  ${tw`mb-3 p-2 border border-white rounded-md`}
+  ${tw`mb-3 p-2 border border-black rounded-md`}
 `
 export const h3 = styled.h3`
   ${tw`text-lightRed text-xl font-semibold hover:text-red`}


### PR DESCRIPTION
# Additions:
- Again, see the commit history for more detail on changes. 
- Essentially we standardized the styling and layout of our Tour Cards to match the work done on the landing page's Services section (InfoBlock cards) which allowed deleting a lot of unecessary styles and simplifying the hover and mobile media query transitions. 
- Changed the TourInfo page's TourGrid section to flex-column on smartphone sized screens with just a single card full width. 
- Numerous styling changes to the TourCard, the inner wrapper and it's related hover and mobile-media-query events. 