### PR TITLE
PR #27 12-23-21 Flight-Instruction-Page finalization 

### DIFF
--- a/backend/schemas/documents/instruction.js
+++ b/backend/schemas/documents/instruction.js
@@ -28,5 +28,12 @@ export default {
       name: "instruction_pricing",
       type: "string",
     },
+    {
+      title: "Instruction Web Ordering",
+      name: "instruction_order",
+      desciption:
+        "This should never change, this is used by the front-end during gatsby-build to position the instruction cards instead of randomly displaying them",
+      type: "string",
+    },
   ],
 };

--- a/frontend/gatsby-node.js
+++ b/frontend/gatsby-node.js
@@ -97,21 +97,23 @@ exports.sourceNodes = async ({ actions: { createNode }, createContentDigest }) =
     const resultData = await result.json();
     console.log('RESULT DATA:  ', resultData);
     resultData.data.forEach((item) => {
-      createNode({
-        parent: null,
-        children: [],
-        internal: {
-          type: item.object,
-          contentDigest: createContentDigest(resultData)
-        },
-        id: item.id,
-        name: item.name,
-        description: item.desc,
-        duration: item.duration,
-        price: item.price,
-        priceType: item.priceType,
-        photoLink: item.photo.id
-      });
+      item.visible
+        ? createNode({
+            parent: null,
+            children: [],
+            internal: {
+              type: item.object,
+              contentDigest: createContentDigest(resultData)
+            },
+            id: item.id,
+            name: item.name,
+            description: item.desc,
+            duration: item.duration,
+            price: item.price,
+            priceType: item.priceType,
+            photoLink: item.photo.id
+          })
+        : console.log('Item skipped.. ');
     });
   } catch (error) {
     console.warn('Error retrieving Xola at build time:  ', error);

--- a/frontend/src/assets/styles/global.css
+++ b/frontend/src/assets/styles/global.css
@@ -85,30 +85,3 @@
 .heroBanner {
   height: 100vh;
 }
-
-/* .scrolledHeadWrapper {
-  margin-left: 0rem;
-} */
-
-/* @media screen and (max-width: 415px) {
-  .logoSpacing {
-    width: 140px;
-  }
-
-  .header {
-    position: static;
-  }
-
-  .scrolledHeader {
-    position: fixed;
-    margin: auto;
-  }
-
-  .heroBanner {
-    height: 40vh;
-  }
-
-  .transparent {
-    display: none;
-  }
-} */

--- a/frontend/src/components/InstructionInfo/index.tsx
+++ b/frontend/src/components/InstructionInfo/index.tsx
@@ -26,9 +26,48 @@ interface SanityFlightInstruction {
 
 const InstructionInfo: React.FC = () => {
 
-    const { allSanityFlightInstruction } = useStaticQuery(graphql`
+    const { allSanityFlightInstruction, discoveryFlight, privateCertificate, commercialCertificate } = useStaticQuery(graphql`
         query {
-            allSanityFlightInstruction {
+            discoveryFlight: sanityFlightInstruction(instruction_order: {eq: "discovery_flight"}){
+                id
+                instruction_type
+                instruction_description
+                instruction_photo {
+                    asset {
+                        url
+                        gatsbyImageData(layout: CONSTRAINED)
+                    }
+                }
+                instruction_booking_link
+                instruction_pricing
+            }
+            privateCertificate: sanityFlightInstruction(instruction_order: {eq: "private_certificate"}){
+                id
+                instruction_type
+                instruction_description
+                instruction_photo {
+                    asset {
+                        url
+                        gatsbyImageData(layout: CONSTRAINED)
+                    }
+                }
+                instruction_booking_link
+                instruction_pricing
+            }
+            commercialCertificate: sanityFlightInstruction(instruction_order: {eq: "commercial_certificate"}){
+                id
+                instruction_type
+                instruction_description
+                instruction_photo {
+                    asset {
+                        url
+                        gatsbyImageData(layout: CONSTRAINED)
+                    }
+                }
+                instruction_booking_link
+                instruction_pricing
+            }
+            allSanityFlightInstruction: allSanityFlightInstruction {
                 edges {
                     node {
                         id
@@ -49,13 +88,23 @@ const InstructionInfo: React.FC = () => {
     `)
 
     const flightInstructionList: SanityFlightInstruction[] = allSanityFlightInstruction.edges;
+    console.log('single private_cert : ', privateCertificate)
     console.log('flightInstructionList: ', flightInstructionList)
 
     return (
         <Container section>
             <TitleSection title="Flight Instruction" subtitle="Rotor and Fixed Wing!" center hero />
             <Styled.InstructionGrid>
-                {
+                <Styled.InstructionInfoItem className="discovery">
+                    <InstructionCard right className="discovery" title={discoveryFlight.instruction_type} description={discoveryFlight.instruction_description} url={discoveryFlight.instruction_photo.asset.url} photo={discoveryFlight.instruction_photo.asset.gatsbyImageData} pricing={discoveryFlight.instruction_pricing} />
+                </Styled.InstructionInfoItem>
+                <Styled.InstructionInfoItem>
+                    <InstructionCard title={privateCertificate.instruction_type} description={privateCertificate.instruction_description} url={privateCertificate.instruction_photo.asset.url} photo={privateCertificate.instruction_photo.asset.gatsbyImageData} pricing={privateCertificate.instruction_pricing} />
+                </Styled.InstructionInfoItem>
+                <Styled.InstructionInfoItem>
+                    <InstructionCard title={commercialCertificate.instruction_type} description={commercialCertificate.instruction_description} url={commercialCertificate.instruction_photo.asset.url} photo={commercialCertificate.instruction_photo.asset.gatsbyImageData} pricing={commercialCertificate.instruction_pricing} />
+                </Styled.InstructionInfoItem>
+                {/* {
                     flightInstructionList.map((element) => {
                         const {
                             instruction_type,
@@ -75,7 +124,7 @@ const InstructionInfo: React.FC = () => {
                             </Styled.InstructionInfoItem>
                         )
                     })
-                }
+                } */}
             </Styled.InstructionGrid>
         </Container>
     )

--- a/frontend/src/components/InstructionInfo/index.tsx
+++ b/frontend/src/components/InstructionInfo/index.tsx
@@ -96,7 +96,7 @@ const InstructionInfo: React.FC = () => {
             <TitleSection title="Flight Instruction" subtitle="Rotor and Fixed Wing!" center hero />
             <Styled.InstructionGrid>
                 <Styled.InstructionInfoItem className="discovery">
-                    <InstructionCard right className="discovery" title={discoveryFlight.instruction_type} description={discoveryFlight.instruction_description} url={discoveryFlight.instruction_photo.asset.url} photo={discoveryFlight.instruction_photo.asset.gatsbyImageData} pricing={discoveryFlight.instruction_pricing} />
+                    <InstructionCard right className="discovery" linkTo="/tours/#61bf4407fc5a3b0d13453a25" title={discoveryFlight.instruction_type} description={discoveryFlight.instruction_description} url={discoveryFlight.instruction_photo.asset.url} photo={discoveryFlight.instruction_photo.asset.gatsbyImageData} pricing={discoveryFlight.instruction_pricing} />
                 </Styled.InstructionInfoItem>
                 <Styled.InstructionInfoItem>
                     <InstructionCard title={privateCertificate.instruction_type} description={privateCertificate.instruction_description} url={privateCertificate.instruction_photo.asset.url} photo={privateCertificate.instruction_photo.asset.gatsbyImageData} pricing={privateCertificate.instruction_pricing} />

--- a/frontend/src/components/InstructionInfo/styles.ts
+++ b/frontend/src/components/InstructionInfo/styles.ts
@@ -9,7 +9,13 @@ export const InstructionGrid = styled.section`
   grid-template-rows: auto;
   grid-gap: 1em;
   
-  div:nth-child(1) {
+  /* div:nth-child(1) {
+    grid-column-start: 1;
+    grid-column-end: 5;
+    grid-row-start: 1;
+    grid-row-end: 2;
+  } */
+  .discovery {
     grid-column-start: 1;
     grid-column-end: 5;
     grid-row-start: 1;
@@ -40,5 +46,5 @@ export const InstructionGrid = styled.section`
 `;
 
 export const InstructionInfoItem = styled.div`
-  ${tw`w-full h-full sm:w-auto shadow-xl`};
+  ${tw`w-full h-full shadow-xl`};
 `;

--- a/frontend/src/components/ui/InstructionCard/index.tsx
+++ b/frontend/src/components/ui/InstructionCard/index.tsx
@@ -27,6 +27,8 @@ interface Props {
     linkTo?: string;
     description: string;
     pricing: string;
+    right?: boolean;
+    className?: string;
 }
 
 const InstructionCard: React.FC<Props> = ({
@@ -35,10 +37,12 @@ const InstructionCard: React.FC<Props> = ({
     url,
     linkTo,
     description,
-    pricing
+    pricing,
+    right,
+    className
 }) => (
-    <Styled.InstructionCard url={url}>
-        <Styled.Wrapper>
+    <Styled.InstructionCard url={url} right={right} className={className} >
+        <Styled.Wrapper right={right}>
             <Styled.Title>
                 {title}
             </Styled.Title>

--- a/frontend/src/components/ui/InstructionCard/index.tsx
+++ b/frontend/src/components/ui/InstructionCard/index.tsx
@@ -51,7 +51,7 @@ const InstructionCard: React.FC<Props> = ({
             <Styled.Content>
                 {description}
             </Styled.Content>
-            <Link to={'/contact'}>
+            <Link to={linkTo ? linkTo : '/contact'}>
                 <Styled.InstructionButton>
                     Click to Contact Us!
                 </Styled.InstructionButton>

--- a/frontend/src/components/ui/InstructionCard/styles.ts
+++ b/frontend/src/components/ui/InstructionCard/styles.ts
@@ -1,9 +1,10 @@
-import styled from 'styled-components';
+import styled, { StyledProps } from 'styled-components';
 import tw from 'tailwind.macro';
 import Button from '../Button';
 import { motion } from 'framer-motion';
 
 interface StyleProps {
+  right?: boolean;
   url?: string;
 }
 
@@ -12,15 +13,17 @@ export const InstructionCard = styled.div<StyleProps>`
   ${({ url }) => url && `background-image: url(${url}); background-position: center; background-size: cover; filter: brightness(.73);`}
   ${tw`flex flex-col m-1 p-1 border rounded-lg border-gray-300`};
   ${tw`hover:border- hover:bg-offWhite`}
+  ${({ right }) => right && tw`flex-row justify-end items-center`}
   &:hover {
     filter: none;
   }
   transition: all 280ms ease-out;
 `;
 
-export const Wrapper = styled.div`
-  ${tw`flex flex-col items-center justify-between p-2 m-2 h-full bg-transparent opacity-80`}
+export const Wrapper = styled.div<StyleProps>`
+  ${tw`flex flex-col items-center justify-between p-1 m-1 h-full bg-transparent opacity-80`}
   ${tw`hover:bg-white hover:opacity-80 hover:border hover:border-red hover:rounded-lg`}
+  ${({ right }) => right && tw`w-1/2 bg-white opacity-75`}
 `;
 
 export const Title = styled.h3`


### PR DESCRIPTION
# Additions: 
- See commit history messages
- Re-formatted the flight instruction 'cards' to be static-queried by specific name instead of just dynamically mapping over all of them (randomly). Allows setting the grid positioning of which flight-instruction service/package exactly where wanted. 
- Restyled the Discovery-Flight main-top card
- Added direct link to the R-44 discovery flight tour on tours page... unfortunately it's pinning the viewport oddly to the very top on the link.
