### PR TITLE
PR 29 12-24-21  Flight Instruction Page and Cards and Title Section Fix

### DIFF
--- a/frontend/src/components/ContactInfo/index.tsx
+++ b/frontend/src/components/ContactInfo/index.tsx
@@ -72,7 +72,7 @@ const ConctactInfo: React.FC = () => {
 
   return (
     <Container section>
-      <TitleSection title={sectionTitle.title} subtitle={sectionTitle.subtitle} hero center />
+      <TitleSection title={sectionTitle.title} subtitle={sectionTitle.subtitle} none hero center />
       {sanityContacts.map((item) => {
         const {
           id,

--- a/frontend/src/components/InstructionInfo/index.tsx
+++ b/frontend/src/components/InstructionInfo/index.tsx
@@ -93,7 +93,7 @@ const InstructionInfo: React.FC = () => {
 
     return (
         <Container section>
-            <TitleSection title="Flight Instruction" subtitle="Rotor and Fixed Wing!" center hero />
+            <TitleSection title="Flight Instruction" subtitle="Rotor and Fixed Wing! You must start with the Discovery Flight, even if you've logged time, you'll need to get familiar with our equipment and instructors through the Discovery Flight" none center hero />
             <Styled.InstructionGrid>
                 <Styled.InstructionInfoItem className="discoveryCert">
                     <InstructionCard right className="discoveryCert" linkTo={`https://checkout.xola.com/index.html#seller/${process.env.GATSBY_XOLA_SELLER_ID}/experiences/61bf4407fc5a3b0d13453a25?openExternal=true`} title={discoveryFlight.instruction_type} description={discoveryFlight.instruction_description} url={discoveryFlight.instruction_photo.asset.url} photo={discoveryFlight.instruction_photo.asset.gatsbyImageData} pricing={discoveryFlight.instruction_pricing} />

--- a/frontend/src/components/InstructionInfo/index.tsx
+++ b/frontend/src/components/InstructionInfo/index.tsx
@@ -95,14 +95,14 @@ const InstructionInfo: React.FC = () => {
         <Container section>
             <TitleSection title="Flight Instruction" subtitle="Rotor and Fixed Wing!" center hero />
             <Styled.InstructionGrid>
-                <Styled.InstructionInfoItem className="discovery">
-                    <InstructionCard right className="discovery" linkTo={`https://checkout.xola.com/index.html#seller/${process.env.GATSBY_XOLA_SELLER_ID}/experiences/61bf4407fc5a3b0d13453a25?openExternal=true`} title={discoveryFlight.instruction_type} description={discoveryFlight.instruction_description} url={discoveryFlight.instruction_photo.asset.url} photo={discoveryFlight.instruction_photo.asset.gatsbyImageData} pricing={discoveryFlight.instruction_pricing} />
+                <Styled.InstructionInfoItem className="discoveryCert">
+                    <InstructionCard right className="discoveryCert" linkTo={`https://checkout.xola.com/index.html#seller/${process.env.GATSBY_XOLA_SELLER_ID}/experiences/61bf4407fc5a3b0d13453a25?openExternal=true`} title={discoveryFlight.instruction_type} description={discoveryFlight.instruction_description} url={discoveryFlight.instruction_photo.asset.url} photo={discoveryFlight.instruction_photo.asset.gatsbyImageData} pricing={discoveryFlight.instruction_pricing} />
                 </Styled.InstructionInfoItem>
-                <Styled.InstructionInfoItem>
-                    <InstructionCard title={privateCertificate.instruction_type} description={privateCertificate.instruction_description} url={privateCertificate.instruction_photo.asset.url} photo={privateCertificate.instruction_photo.asset.gatsbyImageData} pricing={privateCertificate.instruction_pricing} />
+                <Styled.InstructionInfoItem className="privateCert">
+                    <InstructionCard right className="privateCert" title={privateCertificate.instruction_type} description={privateCertificate.instruction_description} url={privateCertificate.instruction_photo.asset.url} photo={privateCertificate.instruction_photo.asset.gatsbyImageData} pricing={privateCertificate.instruction_pricing} />
                 </Styled.InstructionInfoItem>
-                <Styled.InstructionInfoItem>
-                    <InstructionCard title={commercialCertificate.instruction_type} description={commercialCertificate.instruction_description} url={commercialCertificate.instruction_photo.asset.url} photo={commercialCertificate.instruction_photo.asset.gatsbyImageData} pricing={commercialCertificate.instruction_pricing} />
+                <Styled.InstructionInfoItem className="commieCert">
+                    <InstructionCard right className="commieCert" title={commercialCertificate.instruction_type} description={commercialCertificate.instruction_description} url={commercialCertificate.instruction_photo.asset.url} photo={commercialCertificate.instruction_photo.asset.gatsbyImageData} pricing={commercialCertificate.instruction_pricing} />
                 </Styled.InstructionInfoItem>
                 {/* {
                     flightInstructionList.map((element) => {

--- a/frontend/src/components/InstructionInfo/styles.ts
+++ b/frontend/src/components/InstructionInfo/styles.ts
@@ -3,11 +3,10 @@ import tw from 'tailwind.macro';
 
 
 export const InstructionGrid = styled.section`
-  ${tw`m-1 p-1`};
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   grid-template-rows: repeat(4, 0.5fr);
-  grid-gap: 1em;
+  grid-gap: 0.5em;
   
 
   .discoveryCert {

--- a/frontend/src/components/InstructionInfo/styles.ts
+++ b/frontend/src/components/InstructionInfo/styles.ts
@@ -6,34 +6,29 @@ export const InstructionGrid = styled.section`
   ${tw`m-1 p-1`};
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  grid-template-rows: auto;
+  grid-template-rows: repeat(4, 0.5fr);
   grid-gap: 1em;
   
-  /* div:nth-child(1) {
+
+  .discoveryCert {
     grid-column-start: 1;
     grid-column-end: 5;
     grid-row-start: 1;
-    grid-row-end: 2;
-  } */
-  .discovery {
-    grid-column-start: 1;
-    grid-column-end: 5;
-    grid-row-start: 1;
-    grid-row-end: 2;
+    grid-row-end: 3;
   }
 
-  div:nth-child(2) {
+  .privateCert {
     grid-column-start: 1;
     grid-column-end: 3;
     grid-row-start: 3;
-    grid-row-end: 4;
+    grid-row-end: 5
   }
 
-  div:nth-child(3) {
+  .commieCert {
     grid-column-start: 3;
     grid-column-end: 5;
     grid-row-start: 3;
-    grid-row-end: 4;
+    grid-row-end: 5
   }
 
 

--- a/frontend/src/components/Posts/index.tsx
+++ b/frontend/src/components/Posts/index.tsx
@@ -58,7 +58,7 @@ const Posts: React.FC = () => {
 
   return (
     <Container section>
-      <TitleSection title="Blog" subtitle="All Ma Posts" center />
+      <TitleSection title="Blog" none center />
       <Styled.Posts>
         {posts.map((item) => {
           const {

--- a/frontend/src/components/ui/InstructionCard/index.tsx
+++ b/frontend/src/components/ui/InstructionCard/index.tsx
@@ -46,17 +46,18 @@ const InstructionCard: React.FC<Props> = ({
             <Styled.Title>
                 {title}
             </Styled.Title>
-            {/* <GatsbyImage image={photo} alt={title} /> */}
-            {/* <Styled.Wrapper> */}
-            <Styled.Content>
-                {description}
-            </Styled.Content>
-            <Link to={linkTo ? linkTo : '/contact'}>
+
+            <Styled.TextDiv>
+                <Styled.Content>
+                    {description}
+                </Styled.Content>
+            </Styled.TextDiv>
+            <Styled.Linker to={linkTo ? linkTo : '/contact'}>
                 <Styled.InstructionButton>
-                    Click to Contact Us!
+                    Click to Book or Contact!
                 </Styled.InstructionButton>
-            </Link>
-            {/* </Styled.Wrapper> */}
+            </Styled.Linker>
+
         </Styled.Wrapper>
     </Styled.InstructionCard>
 

--- a/frontend/src/components/ui/InstructionCard/styles.ts
+++ b/frontend/src/components/ui/InstructionCard/styles.ts
@@ -10,7 +10,7 @@ interface StyleProps {
 
 export const InstructionCard = styled.div<StyleProps>`
   height: 100%;
-  ${({ url }) => url && `background-image: url(${url}); background-position: center; background-size: cover; filter: brightness(.73);`}
+  ${({ url }) => url && `background-image: url(${url}); background-position: bottom; background-size: cover; filter: brightness(.73);`}
   ${tw`flex flex-col m-1 p-1 border rounded-lg border-gray-300`};
   ${tw`hover:border- hover:bg-offWhite`}
   ${({ right }) => right && tw`flex-row justify-end items-center`}

--- a/frontend/src/components/ui/InstructionCard/styles.ts
+++ b/frontend/src/components/ui/InstructionCard/styles.ts
@@ -1,6 +1,7 @@
 import styled, { StyledProps } from 'styled-components';
 import tw from 'tailwind.macro';
 import Button from '../Button';
+import { Link } from 'gatsby';
 import { motion } from 'framer-motion';
 
 interface StyleProps {
@@ -11,32 +12,43 @@ interface StyleProps {
 export const InstructionCard = styled.div<StyleProps>`
   height: 100%;
   ${({ url }) => url && `background-image: url(${url}); background-position: bottom; background-size: cover; filter: brightness(.73);`}
-  ${tw`flex flex-col m-1 p-1 border rounded-lg border-gray-300`};
+  ${tw`flex flex-col py-1 border rounded-lg border-gray-300`};
   ${tw`hover:border- hover:bg-offWhite`}
   ${({ right }) => right && tw`flex-row justify-end items-center`}
   &:hover {
     filter: none;
   }
   transition: all 280ms ease-out;
+  @media screen and (max-width: 425px) {
+    height: 350px;
+  }
 `;
 
 export const Wrapper = styled.div<StyleProps>`
-  ${tw`flex flex-col items-center justify-between p-1 m-1 h-full bg-transparent opacity-80`}
-  ${tw`hover:bg-white hover:opacity-80 hover:border hover:border-red hover:rounded-lg`}
-  ${({ right }) => right && tw`w-1/2 bg-white opacity-75`}
+  ${tw`flex flex-col h-full sm:p-1 sm:m-1 p-2 items-center justify-between bg-ghostWhite opacity-80 border border-black rounded-lg`}
+  ${tw`hover:bg-white hover:opacity-80 hover:border hover:border-red`}
+  ${({ right }) => right && tw`w-1/2 bg-ghostWhite opacity-95`}
 `;
 
 export const Title = styled.h3`
-  ${tw`sm:text-2xl text-red mb-4 font-semibold text-center`};
+  ${tw`sm:text-3xl text-red sm:my-3 font-semibold text-center`};
+`;
+
+export const TextDiv = styled.div`
+  ${tw`flex flex-col m-1 border rounded border-black p-1 overflow-auto`}
 `;
 
 export const Content = styled.p`
-  ${tw`sm:m-2 p-1 sm:p-3 text-black text-center sm:text-lg`};
+  ${tw`sm:m-2 p-1 sm:p-3 text-black text-center text-sm sm:text-lg`};
+`;
+
+export const Linker = styled(Link)`
+  ${tw`sm:p-2 sm:m-1 `};
 `;
 
 export const InstructionButton = motion.custom(styled.button`
   font-family: "GoodTimes", monospace;
-  ${tw`py-1 px-4 sm:py-2 sm:px-8 rounded-full border border-red text-black`};
+  ${tw`sm:p-2 sm:m-2 rounded-full border border-red text-black text-xs sm:text-base`};
   transition: background-color 1s, transform 1s;
   & :hover {
     ${tw`bg-lightRed`}

--- a/frontend/src/components/ui/TitleSection/index.tsx
+++ b/frontend/src/components/ui/TitleSection/index.tsx
@@ -12,8 +12,8 @@ interface Props extends StyledProps {
 
 const TitleSection: React.FC<Props> = ({ center, hero, none, title, subtitle }) => (
   <Styled.TitleSection >
-    {subtitle && <Styled.SubTitle hero={hero} center={center}>{subtitle}</Styled.SubTitle>}
     <Styled.Title hero={hero} center={center}>{title}</Styled.Title>
+    {subtitle && <Styled.SubTitle hero={hero} center={center}>{subtitle}</Styled.SubTitle>}
     <Styled.Separator none={none} center={center} />
   </Styled.TitleSection>
 );

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -8,6 +8,7 @@ module.exports = {
         darkRed: '#941a1a',
         black: '#1f1f1f',
         offWhite: '#f3f1f0',
+        ghostWhite: '#f8f8ff',
         slate: 'rgb(148,148,148)',
         veryLightGrey: '#e7ebed',
         teal2: '#2ad4d4',
@@ -16,6 +17,7 @@ module.exports = {
       },
       height: {
         card: '400px',
+        responsiveCard: '400px',
         mobile: '4rem',
         initial: '150px',
         scrolled: '55px',


### PR DESCRIPTION
## Additions: 
- Definitely check commit messages as we added more style changes and responsive chages to the Flight Instruction page, grid, and individual cards. 
- Changed the Title component app-wide to either not display the 'separator' component, the subtitle, or both.
