### PR TITLE
Hotfix 12-25-21 Header and Layout 

### DIFF
--- a/frontend/src/assets/styles/global.css
+++ b/frontend/src/assets/styles/global.css
@@ -84,4 +84,5 @@
 
 .heroBanner {
   height: 100vh;
+  top: -120px;
 }

--- a/frontend/src/components/Header/styles.ts
+++ b/frontend/src/components/Header/styles.ts
@@ -7,11 +7,11 @@ interface ScrollStyles {
 }
 
 export const Header = styled.header<ScrollStyles>`
-  ${tw`fixed w-full h-initial z-50 bg-transparent `};
+  ${tw`sticky top-0 w-full h-initial z-50 bg-transparent `};
   ${({ scrolled }) => scrolled && tw`sm:bg-red sm:h-scrolled`};
   transition: all 0.5s linear;
   @media screen and (max-width: 425px) {
-    ${tw`fixed bg-red h-12`};
+    ${tw`sticky top-0 bg-red h-12`};
   }
 `;
 

--- a/frontend/src/components/Layout/styles.ts
+++ b/frontend/src/components/Layout/styles.ts
@@ -4,7 +4,7 @@ import { motion } from 'framer-motion';
 
 
 export const MotionLayoutContainer = motion.custom(styled.div`
- 
+  
 `)
 
 export const Layout = styled.main`

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -22,7 +22,8 @@ module.exports = {
         initial: '120px',
         scrolled: '80px',
         mobHeader: '6.5rem',
-        mainHeader: '8.85rem'
+        mainHeader: '8.85rem',
+        layoutTop: '130px'
       },
       width: {
         mobile: '8rem'


### PR DESCRIPTION
## Additons/Changes

- See commit message history. Changes the header to sticky top-0 instead of fixed .. solved the transparent landing page background image by giving it a negative top position in global.css
