### PR TITLE
PR #36 12-30-21 Tour and Service/Info Card Responsive Opacity Fix

### DIFF
--- a/frontend/src/components/ui/InfoBlock/styles.ts
+++ b/frontend/src/components/ui/InfoBlock/styles.ts
@@ -24,11 +24,16 @@ export const Icon = styled.span`
 `;
 
 export const Wrapper = styled.div<StyledProps>`
-  ${tw`p-2 m-2 h-full bg-transparent opacity-75`}
-  ${tw`hover:bg-white hover:opacity-80 hover:border hover:border-red hover:rounded-lg`}
+  ${tw`p-2 m-2 h-full sm:bg-transparent opacity-75 bg-white`}
+  ${tw`hover:bg-white hover:opacity-90 hover:border hover:border-red hover:rounded-lg`}
+  &:hover {
+    opacity: 0.9;
+  }
 `;
 
 export const Title = styled.h3`
+  font-family: 'GoodTimes', monospace;
+  text-shadow: 1px 1px 1px black;
   ${tw`text-md mt-1 text-red font-semibold`};
 `;
 

--- a/frontend/src/components/ui/TitleSection/styles.ts
+++ b/frontend/src/components/ui/TitleSection/styles.ts
@@ -12,12 +12,16 @@ export const TitleSection = styled.div`
 `;
 
 export const Title = styled.h2<StyledProps>`
+  font-family: 'GoodTimes', monospace;
+  text-shadow: 1px 1px 1px black;
   ${tw`uppercase mb-4 text-lg font-bold w-full text-left`};
   ${({ center }) => center && tw`text-center`};
   ${({ hero }) => hero && tw`sm:text-3xl text-black`}
 `;
 
 export const SubTitle = styled.h4<StyledProps>`
+  font-family: 'GoodTimes', monospace;
+  text-shadow: 1px 1px 1px black;
   ${tw`text-xs text-lightRed w-full text-left`};
   ${({ center }) => center && tw`text-center`};
   ${({ hero }) => hero && tw`sm:text-lg text-indigo sm:mb-8`};

--- a/frontend/src/components/ui/TourCard/styles.ts
+++ b/frontend/src/components/ui/TourCard/styles.ts
@@ -21,8 +21,11 @@ export const Icon = styled.span`
 `;
 
 export const Wrapper = styled.div<StyledProps>`
-  ${tw`flex flex-col justify-between p-2 m-2 h-full bg-transparent opacity-82`}
+  ${tw`flex flex-col justify-between p-2 m-2 h-full bg-white opacity-80 sm:bg-transparent`}
   ${tw`hover:bg-white hover:opacity-80 hover:border hover:border-red`}
+  &:hover {
+    opacity: 0.9;
+  }
 `;
 
 export const DescriptionWrapper = styled.div`
@@ -40,7 +43,7 @@ export const Title = styled.h3`
 `;
 
 export const Content = styled.p`
-  ${tw`mt-1 text-ellipsis text-black text-center`};
+  ${tw`mt-1 text-ellipsis sm:text-lg text-black text-center`};
 `;
 
 export const Link = styled.a<StyledProps>`


### PR DESCRIPTION
## Additions:
- Essentially all mobilve (small) screens will have a fixed opacity of about 80% since mobile screens won't be able to utilize the hover state.
- Manually set the on-hover value of 90% on desktop screens since tailwind wasn't working.
- Bumped text size on TourCard content text for desktop